### PR TITLE
Refactor agent

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,44 +1,66 @@
 from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from typing import Type
+
 import numpy as np
 
 
-class Agent:
+class Agent(ABC):
 
-    agent_dict = {}  # initialise to zero
+    agent_dict = defaultdict(int)  # initialised to zero
+    agent_count = 0
 
-    def __init__(self, label: str, strategy_set: dict = None):
-
-        self.label = label
-        self.strategy_set = strategy_set
-        self.id = Agent.agent_dict[label] + 1 if label in Agent.agent_dict else 0   ## I don't understand this
-        Agent.agent_dict[label] = self.id
+    def __init__(self):
+        self.id = Agent.agent_count  ##  The id should be unique irrespective of the type
+        Agent.agent_count += 1
+        Agent.agent_dict[self.type] += 1
 
     def __repr__(self):
-        return (f"Label: {self.label} \n"
-                f"ID: {self.id} \n"
-                f"Strategy Set: {self.strategy_set} \n")
+        return (f"Type: {self.type.__name__} \n"
+                f"ID: {self.id} \n")
 
-    def __copy__(self):
-        new_agent = Agent(self.label, self.strategy_set)
-        return new_agent
+    def __str__(self):
+        return f"{self.type.__name__}(ID={self.id})"
 
-    def get_action(self, opponent: Agent):
-        strategy = self.strategy_set[opponent.label]
+    @property
+    def type(self) -> Type[Agent]:
+        return self.__class__
+
+    @property
+    def label(self) -> str:
+        return self.type.__name__
+
+    @abstractmethod
+    def get_action(self, opponent: Agent) -> int:
+        raise NotImplementedError
+
+
+class SatisfiaAgent(Agent):
+
+    def __init__(self, strategy_set: dict):
+        super().__init__()
+        self.strategy_set = strategy_set
+
+    def get_action(self, opponent: Agent) -> int:
+        strategy = self.strategy_set[opponent.type]
         action = np.random.choice(strategy['actions'],
                                   p=strategy['probabilities'])
         return action
 
 
-class SatisfiaAgent(Agent):
-
-    def __init__(self, strategy_set):
-        super().__init__('satisfia', strategy_set)
-
-
 class MaximiserAgent(Agent):
 
-    def __init__(self, strategy_set):
-        super().__init__('maximiser', strategy_set)
+    def __init__(self, strategy_set: dict):
+        super().__init__()
+        self.strategy_set = strategy_set
+
+    def get_action(self, opponent: Agent) -> int:
+        strategy = self.strategy_set[opponent.type]
+        action = np.random.choice(strategy['actions'],
+                                  p=strategy['probabilities'])
+        return action
 
 
 if __name__ == '__main__':
@@ -62,14 +84,10 @@ if __name__ == '__main__':
     maximiser = MaximiserAgent(strategy_set=maximiser_set)
 
     satisfier2 = SatisfiaAgent(strategy_set=satisfia_set)
-
-    satisfier = Agent('satisfia')
-    satisfier2 = Agent('satisfia')
-    satisfier3 = Agent('satisfia')
-
-    maximiser = Agent('maximiser')
-    maximiser2 = Agent('maximiser')
-    maximiser3 = maximiser.__copy__()
+    print(satisfier2.type)
+    print(maximiser.type)
+    print(repr(satisfier))
+    print(maximiser)
 
 
 

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import numpy as np
 
 
@@ -5,12 +6,10 @@ class Agent:
 
     agent_dict = {}  # initialise to zero
 
-    def __init__(self, label: str, strategy_set: dict = None, opponent=None, strategy=None):
+    def __init__(self, label: str, strategy_set: dict = None):
 
         self.label = label
         self.strategy_set = strategy_set
-        self.strategy = strategy
-        self.opponent = opponent
         self.id = Agent.agent_dict[label] + 1 if label in Agent.agent_dict else 0   ## I don't understand this
         Agent.agent_dict[label] = self.id
 
@@ -23,24 +22,18 @@ class Agent:
         new_agent = Agent(self.label, self.strategy_set)
         return new_agent
 
-    def set_opponent(self, agent):
-        self.opponent = agent
-
-    def set_strategy_set(self, strategy_set):
-        self.strategy_set = strategy_set
-
-    def choose_strategy(self):
-        self.strategy = self.strategy_set[self.opponent.label]
-
-    def get_action(self):
-        action = np.random.choice(self.strategy['actions'],
-                                  p=self.strategy['probabilities'])
+    def get_action(self, opponent: Agent):
+        strategy = self.strategy_set[opponent.label]
+        action = np.random.choice(strategy['actions'],
+                                  p=strategy['probabilities'])
         return action
+
 
 class SatisfiaAgent(Agent):
 
     def __init__(self, strategy_set):
         super().__init__('satisfia', strategy_set)
+
 
 class MaximiserAgent(Agent):
 

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -61,15 +61,15 @@ if __name__ == '__main__':
     # Iterated JobstGame example
     options = JobstGame.row_options
     maximiser = MaximiserAgent({
-        'satisfia': {'actions': options,
+        SatisfiaAgent: {'actions': options,
                     'probabilities': [0, 0, 0, 0, 0, 1]},  # I changed this one
-        'maximiser': {'actions': options,
+        MaximiserAgent: {'actions': options,
                     'probabilities': [0, 0, 0, 0, 0, 1]}
     })
     satisfia = SatisfiaAgent({
-        'satisfia': {'actions': options,
+        SatisfiaAgent: {'actions': options,
                     'probabilities': [0, 0, 0, 1, 0, 0]},
-        'maximiser': {'actions': options,
+        MaximiserAgent: {'actions': options,
                     'probabilities': [0, 1, 0, 0, 0, 0]}
     })
 

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -20,18 +20,12 @@ class Game:
         return reward
 
     def play_n_rounds(self, n: int, row_agent: Agent, column_agent: Agent, plot=False) -> tuple[npt.NDArray[int], npt.NDArray[int]]:
-        row_agent.set_opponent(column_agent)
-        column_agent.set_opponent(row_agent)
-
         actions = np.zeros((2, n), dtype=int)
         rewards = np.zeros((2, n), dtype=int)
 
         for round in range(n):
-            row_agent.choose_strategy()   ## Should this be done at every round?
-            column_agent.choose_strategy()
-
-            row_action = row_agent.get_action()
-            column_action = column_agent.get_action()
+            row_action = row_agent.get_action(column_agent)
+            column_action = column_agent.get_action(row_agent)
             row_reward, column_reward = self.get_reward(row_action, column_action)
 
             actions[:, round] = [row_action, column_action]
@@ -64,12 +58,11 @@ if __name__ == '__main__':
     # prisoners_dilemma = prisoners_dilemma.reshape((2, 2))
     defaultGame = Game(prisoners_dilemma)
 
-
     # Iterated JobstGame example
     options = JobstGame.row_options
     maximiser = MaximiserAgent({
         'satisfia': {'actions': options,
-                    'probabilities': [0, 0, 0, 0, 0, 1]}, # I changed this one
+                    'probabilities': [0, 0, 0, 0, 0, 1]},  # I changed this one
         'maximiser': {'actions': options,
                     'probabilities': [0, 0, 0, 0, 0, 1]}
     })

--- a/monte_carlo/__init__.py
+++ b/monte_carlo/__init__.py
@@ -32,14 +32,8 @@ class MonteCarlo:
 
     def play_game(self, agent1: agents.Agent, agent2: agents.Agent):
 
-        agent1.set_opponent(agent2)
-        agent2.set_opponent(agent1)
-
-        agent1.choose_strategy()
-        agent2.choose_strategy()
-
-        action1 = agent1.get_action()
-        action2 = agent2.get_action()
+        action1 = agent1.get_action(agent2)
+        action2 = agent2.get_action(agent1)
 
         r1, r2 = self.game.get_reward(action1, action2)   # maybe want to have reward as an attribute for agent?
         self.reward_dict[agent1.label] += max(0, r1)

--- a/monte_carlo/__init__.py
+++ b/monte_carlo/__init__.py
@@ -1,15 +1,16 @@
 import random
+from collections import defaultdict
 
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 
 import agents
+from agents import SatisfiaAgent, MaximiserAgent
 from game import Game, JobstGame
 
 
 class MonteCarlo:
-
 
     def __init__(self, game: Game, strategy_set: dict,
                  agent_list: npt.NDArray[agents.Agent] = np.array([]),
@@ -19,8 +20,8 @@ class MonteCarlo:
         self.agent_list = agent_list
         self.strategy_set = strategy_set
         self.generations = generations
-        self.agent_types = set([agent.label for agent in self.agent_list])
-        self.reward_dict = {agent_type: 0 for agent_type in self.agent_types}
+        self.agent_types = set([agent.type for agent in self.agent_list])
+        self.reward_dict = defaultdict(int)
         self.agent_counts = {agent_type: np.array([count+1]) for agent_type, count in agents.Agent.agent_dict.items()}
 
     def __repr__(self):
@@ -36,8 +37,8 @@ class MonteCarlo:
         action2 = agent2.get_action(agent1)
 
         r1, r2 = self.game.get_reward(action1, action2)   # maybe want to have reward as an attribute for agent?
-        self.reward_dict[agent1.label] += max(0, r1)
-        self.reward_dict[agent2.label] += max(0, r2)
+        self.reward_dict[type(agent1)] += max(0, r1)
+        self.reward_dict[type(agent2)] += max(0, r2)
 
     def play_all_games(self):
 
@@ -50,15 +51,15 @@ class MonteCarlo:
 
         total_reward = sum(self.reward_dict.values())
         n_agents_total = len(self.agent_list)
-        agents.Agent.agent_dict = {}  # reset class variable to empty
+        agents.Agent.agent_dict = defaultdict(int)  # reset class variable to empty
         self.agent_list = np.array([])
         for agent_type, r in self.reward_dict.items():
             n_agents = round((r/total_reward)*n_agents_total)
             if n_agents > 0:
                 self.agent_list = np.append(self.agent_list,
-                                            np.array([agents.Agent(agent_type,
-                                                      self.strategy_set[agent_type]) for _ in range(n_agents)]))
-            self.agent_counts[agent_type] = np.append(self.agent_counts[agent_type], n_agents)
+                                            np.array([agent_type(self.strategy_set[agent_type])
+                                                      for _ in range(n_agents)]))
+            self.agent_counts[agent_type] = np.append(self.agent_counts[agent_type], n_agents)  ## Redundant with the agent_dict of the Agent class
 
     def iterate_generations(self, plot: bool = False):
 
@@ -78,7 +79,7 @@ class MonteCarlo:
         fig, ax = plt.subplots(figsize=(10, 10))
         total_agents = len(self.agent_list)
         for agent_type, agent_counts in self.agent_counts.items():
-            ax.plot(agent_counts/total_agents, label=agent_type)
+            ax.plot(agent_counts/total_agents, label=agent_type.__name__)
 
         plt.title('Plot of agent populations over generations')
         ax.set_xlabel('Generation')
@@ -90,26 +91,26 @@ class MonteCarlo:
 if __name__ == '__main__':
 
     options = [0,1,2,3,4,5]
-    satisfia_set = {'satisfia': {'actions': options,
+    satisfia_set = {SatisfiaAgent: {'actions': options,
                                  'probabilities': [0, 0, 0, 1, 0, 0]},
-                    'maximiser': {'actions': options,
+                    MaximiserAgent: {'actions': options,
                                   'probabilities': [0, 1, 0, 0, 0, 0]}
                     }
 
-    maximiser_set = {'satisfia': {'actions': options,
+    maximiser_set = {SatisfiaAgent: {'actions': options,
                                   'probabilities': [0, 1, 0, 0, 0, 0]},
-                     'maximiser': {'actions': options,
+                     MaximiserAgent: {'actions': options,
                                    'probabilities': [0, 0, 0, 0, 0, 1]}
                      }
 
-    BIG_STRATEGY_SET = {'satisfia': satisfia_set, 'maximiser': maximiser_set}  # we should make this into a table or smth
-    satisfias = np.array([agents.Agent('satisfia', satisfia_set) for _ in range(720)])
-    maximisers = np.array([agents.Agent('maximiser', maximiser_set) for _ in range(280)])
+    BIG_STRATEGY_SET = {SatisfiaAgent: satisfia_set, MaximiserAgent: maximiser_set}  # we should make this into a table or smth
+    satisfias = np.array([agents.SatisfiaAgent(satisfia_set) for _ in range(720)])
+    maximisers = np.array([agents.MaximiserAgent(maximiser_set) for _ in range(280)])
     AGENT_LIST = np.append(satisfias, maximisers)
     GAME = JobstGame
     GENERATIONS = 100
     mc = MonteCarlo(GAME, BIG_STRATEGY_SET, AGENT_LIST, GENERATIONS)
 
-    agent_counts_final = mc.iterate_generations()
-    if agent_counts_final['maximiser'] > agent_counts_final['satisfia']:
+    agent_counts_final = mc.iterate_generations(plot=True)
+    if agent_counts_final[MaximiserAgent] > agent_counts_final[SatisfiaAgent]:
         print(True)


### PR DESCRIPTION
- Use inheritance to make agent types
- Remove Agent methods that are currently not used
- Remove the string label for agent types. Use the class type instead
- label and type are now properties of the Agent class. Label is nothing more that the name of the class (type.__name__)
- Changed the counts and ids in the Agent class (still not sure whether the agent type counts should be kept in the Agent class or simply moved to MonteCarlo class)